### PR TITLE
perf: stop shipping full Pokémon dataset to client; fix React/lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,89 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Pokemizer
 
-## Getting Started
+Build a random Pokémon team through a card-flip game. Pick a generation and game
+version, get a random starter, then flip cards to assemble a team of six under
+type-overlap rules. Completed teams are saved to local history and can be shared
+via a compact, URL-safe code.
 
-First, run the development server:
+Live site: <https://pokemizer.com>
+
+## Tech stack
+
+- **Next.js 16** (App Router, Turbopack) with the **React Compiler** enabled
+- **React 19**
+- **Tailwind CSS v4** + **shadcn/ui** (Radix primitives)
+- **TypeScript**
+- **Vercel Analytics**
+- Bun as the package manager / script runner
+
+## Getting started
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
+bun install
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open <http://localhost:3000>.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Scripts
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Command | Description |
+| --- | --- |
+| `bun dev` | Start the dev server |
+| `bun run build` | Production build |
+| `bun start` | Serve the production build |
+| `bun run lint` | Run ESLint |
 
-## Learn More
+## Project structure
 
-To learn more about Next.js, take a look at the following resources:
+```
+src/
+  app/                 App Router routes
+    play/[game]/       Game screen (SSG per game version)
+    t/[code]/          Shared-team view (resolves a share code)
+    history/           Locally-saved team history
+  components/          UI + game components
+  hooks/               use-game-state (reducer), use-local-storage
+  lib/
+    games.ts           Game version metadata + lookups
+    starters.ts        Generation/starter metadata
+    game-logic.ts      Team rules, type coverage
+    pokemon-utils.ts   Weighted random card dealing
+    share.ts           Client-safe encode/decode of share codes
+    share-resolve.ts   Server-only: resolve a code to full data
+  data/                Per-game Pokémon JSON (generated) + barrel
+scripts/
+  generate-pokemon-data.ts   Fetches PokeAPI → src/data/*.json
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Pokémon data
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Per-game data lives in `src/data/*.json` as `EvolutionLine[]`. It is generated
+from [PokeAPI](https://pokeapi.co) by:
 
-## Deploy on Vercel
+```bash
+bun scripts/generate-pokemon-data.ts
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Sprites are served from the PokeAPI sprites CDN (`raw.githubusercontent.com`)
+and cached by the service worker (`public/sw.js`).
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+### Data loading note
+
+`src/data/index.ts` is a barrel that statically imports every game's JSON. It is
+**server-only** — importing it from a Client Component pulls the entire dataset
+into the browser bundle. Client code must only import `share.ts` (encode/decode);
+full-data resolution lives in the server-only `share-resolve.ts`.
+
+## Sharing
+
+Teams are encoded into a compact binary payload (game index + member refs +
+attempts + CRC-8), then base64url-encoded into `/t/<code>`. The format is
+**append-only** — see the warnings in `src/lib/share.ts` before editing the
+game-index maps, as changes break existing shared links.
+
+## Disclaimer
+
+Pokemizer is an unofficial fan project and is not affiliated with, endorsed, or
+supported by Nintendo, Game Freak, or The Pokémon Company. Pokémon and Pokémon
+character names are trademarks of Nintendo.

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,7 +1,13 @@
 "use client";
 
+import { useMemo } from "react";
 import Link from "next/link";
-import type { TeamHistoryEntry, EvolutionLine } from "@/lib/types";
+import type {
+  TeamHistoryEntry,
+  LegacyTeamHistoryEntry,
+  EvolutionLine,
+  Pokemon,
+} from "@/lib/types";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { EvolutionStageViewer } from "@/components/evolution-stage-viewer";
 import { ShareButton } from "@/components/share-button";
@@ -10,7 +16,9 @@ import { ArrowLeft, Trash2 } from "lucide-react";
 
 // --- History migration helpers ---
 
-function migrateOldPokemon(pokemon: any): EvolutionLine {
+type StoredHistoryEntry = TeamHistoryEntry | LegacyTeamHistoryEntry;
+
+function migrateOldPokemon(pokemon: Pokemon): EvolutionLine {
   return {
     lineId: pokemon.id,
     stages: [{
@@ -27,25 +35,28 @@ function migrateOldPokemon(pokemon: any): EvolutionLine {
   };
 }
 
-function isLegacyEntry(entry: any): boolean {
-  return entry.team?.length > 0 && !('lineId' in entry.team[0]);
+function isLegacyEntry(entry: StoredHistoryEntry): entry is LegacyTeamHistoryEntry {
+  return entry.team?.length > 0 && !("lineId" in entry.team[0]);
 }
 
-function migrateEntry(entry: any): TeamHistoryEntry {
+function migrateEntry(entry: StoredHistoryEntry): TeamHistoryEntry {
   if (isLegacyEntry(entry)) {
     return {
       ...entry,
       team: entry.team.map(migrateOldPokemon),
     };
   }
-  return entry as TeamHistoryEntry;
+  return entry;
 }
 
 // --- Page component ---
 
 export default function HistoryPage() {
-  const [rawHistory, setRawHistory] = useLocalStorage<any[]>("team-history", []);
-  const history: TeamHistoryEntry[] = rawHistory.map(migrateEntry);
+  const [rawHistory, setRawHistory] = useLocalStorage<StoredHistoryEntry[]>("team-history", []);
+  const history: TeamHistoryEntry[] = useMemo(
+    () => rawHistory.map(migrateEntry),
+    [rawHistory],
+  );
 
   const clearHistory = () => {
     setRawHistory([]);

--- a/src/app/icon-192/route.tsx
+++ b/src/app/icon-192/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
+export const dynamic = "force-static";
 
 export async function GET() {
   return new ImageResponse(

--- a/src/app/icon-512/route.tsx
+++ b/src/app/icon-512/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
+export const dynamic = "force-static";
 
 export async function GET() {
   return new ImageResponse(

--- a/src/app/play/[game]/game-client.tsx
+++ b/src/app/play/[game]/game-client.tsx
@@ -53,13 +53,22 @@ export function GameClient({ generation, gameVersion, allPokemon }: GameClientPr
   const [duplicateIndex, setDuplicateIndex] = useState<number | null>(null);
   const initRef = useRef(false);
   const teamRef = useRef(state.team);
-  teamRef.current = state.team;
 
-  // Initialize game on mount
+  // Keep a ref to the latest team so deferred setTimeout callbacks in
+  // handleReveal read the current team without stale closures. Updated in an
+  // effect (not during render) per the rules of refs.
+  useEffect(() => {
+    teamRef.current = state.team;
+  }, [state.team]);
+
+  // Initialize game on mount. This must run client-side only: the starter is
+  // chosen randomly, so computing it during render (or in a useState
+  // initializer) would cause a server/client hydration mismatch.
   useEffect(() => {
     if (!initRef.current) {
       initRef.current = true;
       const starter = getRandomStarter(allPokemon);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- mount-only randomized init, see comment above
       setStarterLine(starter);
       setGame(generation, gameVersion, allPokemon);
     }
@@ -262,9 +271,8 @@ export function GameClient({ generation, gameVersion, allPokemon }: GameClientPr
             {/* Action bar — shown after reveal (non-duplicate) */}
             {showActionBar && revealedLine && (
               <ActionBar
-                line={revealedLine}
-                scenario={getActionScenario(teamRef.current, revealedLine)}
-                coverageDelta={getTypeCoverageDelta(teamRef.current, revealedLine)}
+                scenario={getActionScenario(state.team, revealedLine)}
+                coverageDelta={getTypeCoverageDelta(state.team, revealedLine)}
                 onAdd={handleAdd}
                 onReplace={handleStartReplace}
                 onSkip={handleSkip}

--- a/src/app/t/[code]/page.tsx
+++ b/src/app/t/[code]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { resolveShareCode } from "@/lib/share";
+import { resolveShareCode } from "@/lib/share-resolve";
 import { getTypeCoverage } from "@/lib/game-logic";
 import { capitalize } from "@/lib/utils";
 import { SharedTeamView } from "@/components/shared-team-view";

--- a/src/components/action-bar.tsx
+++ b/src/components/action-bar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { EvolutionLine } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Plus, ArrowLeftRight, SkipForward } from "lucide-react";
@@ -8,7 +7,6 @@ import { Plus, ArrowLeftRight, SkipForward } from "lucide-react";
 type ActionScenario = "add" | "add-with-overlap" | "replace-or-skip";
 
 interface ActionBarProps {
-  line: EvolutionLine;
   scenario: ActionScenario;
   coverageDelta: { before: number; after: number; delta: number };
   onAdd: () => void;
@@ -18,7 +16,6 @@ interface ActionBarProps {
 }
 
 export function ActionBar({
-  line,
   scenario,
   coverageDelta,
   onAdd,

--- a/src/components/game-over.tsx
+++ b/src/components/game-over.tsx
@@ -27,7 +27,7 @@ export function GameOver({
   onPlayAgain,
   onNewGeneration,
 }: GameOverProps) {
-  const [history, setHistory] = useLocalStorage<TeamHistoryEntry[]>("team-history", []);
+  const [, setHistory] = useLocalStorage<TeamHistoryEntry[]>("team-history", []);
   const savedRef = useRef(false);
 
   useEffect(() => {

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { track } from "@vercel/analytics";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Share2, Check, Link as LinkIcon } from "lucide-react";
+import { Share2, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { encodeTeamShareCode } from "@/lib/share";
 import type { EvolutionLine, GameVersion } from "@/lib/types";

--- a/src/components/stat-chart.tsx
+++ b/src/components/stat-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { BaseStats, PokemonType } from "@/lib/types";
+import type { BaseStats } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 const STAT_ROWS: { label: string; key: keyof BaseStats; color: string }[] = [
@@ -16,7 +16,6 @@ const MAX_STAT = 255;
 
 interface StatChartProps {
   stats: BaseStats;
-  primaryType?: PokemonType;
   className?: string;
 }
 

--- a/src/hooks/use-game-state.ts
+++ b/src/hooks/use-game-state.ts
@@ -3,7 +3,7 @@
 import { useCallback, useReducer } from "react";
 import type { GameState, EvolutionLine, Generation, GameVersion } from "@/lib/types";
 import { getRandomCards } from "@/lib/pokemon-utils";
-import { isGameOver, isTeamFull } from "@/lib/game-logic";
+import { isGameOver } from "@/lib/game-logic";
 
 type GameAction =
   | { type: "SET_GAME"; generation: Generation; gameVersion: GameVersion; allPokemon: EvolutionLine[] }

--- a/src/lib/game-logic.ts
+++ b/src/lib/game-logic.ts
@@ -33,15 +33,6 @@ export function getTypeCoverage(team: EvolutionLine[]): number {
   return getTeamTypes(team).length;
 }
 
-/** Returns indices of team members that share at least one type with the new line */
-export function getOverlappingTeamIndices(team: EvolutionLine[], line: EvolutionLine): number[] {
-  const newTypes = new Set(line.types);
-  return team
-    .map((member, index) => ({ member, index }))
-    .filter(({ member }) => member.types.some((t) => newTypes.has(t)))
-    .map(({ index }) => index);
-}
-
 /** Calculate type coverage delta if this line were added to the team */
 export function getTypeCoverageDelta(
   team: EvolutionLine[],
@@ -77,9 +68,4 @@ export function getReplaceableIndices(team: EvolutionLine[]): number[] {
     .map((member, index) => ({ member, index }))
     .filter(({ member }) => !member.isStarter)
     .map(({ index }) => index);
-}
-
-/** Check if a specific lineId is already on the team */
-export function isLineOnTeam(team: EvolutionLine[], lineId: number): boolean {
-  return team.some((l) => l.lineId === lineId);
 }

--- a/src/lib/share-resolve.ts
+++ b/src/lib/share-resolve.ts
@@ -1,0 +1,58 @@
+import type { EvolutionLine, GameVersion, Generation } from "@/lib/types";
+import { getGameData } from "@/data";
+import { getGameVersion, getGenerationForGame } from "@/lib/games";
+import { decodeShareCode } from "@/lib/share";
+
+// ---------------------------------------------------------------------------
+// Resolve (full data lookup)
+//
+// ⚠️ Server-only: this module imports the full `@/data` barrel (all games).
+// Keep it out of client component graphs so the ~2.9MB data chunk is never
+// shipped to the browser. Import it only from server components / route
+// handlers (e.g. `t/[code]/page.tsx`).
+// ---------------------------------------------------------------------------
+
+export interface ResolvedShareData {
+  gameVersion: GameVersion;
+  generation: Generation;
+  team: EvolutionLine[];
+  attempts: number;
+}
+
+/** Decode + resolve full EvolutionLine objects from static game data. Returns null on any failure. */
+export function resolveShareCode(code: string): ResolvedShareData | null {
+  const payload = decodeShareCode(code);
+  if (!payload) return null;
+
+  // 1. getGameData must return data
+  const data = getGameData(payload.gameSlug);
+  if (!data) return null;
+
+  // 2. Each member must be found in game data
+  const team: EvolutionLine[] = [];
+  for (const ref of payload.members) {
+    const line = data.find(
+      (l) =>
+        l.lineId === ref.lineId &&
+        (ref.branchIndex === undefined
+          ? l.branchIndex === undefined
+          : l.branchIndex === ref.branchIndex),
+    );
+    if (!line) return null;
+    team.push(line);
+  }
+
+  // 3. getGameVersion and getGenerationForGame must return values
+  const gameVersion = getGameVersion(payload.gameSlug);
+  if (!gameVersion) return null;
+
+  const generation = getGenerationForGame(gameVersion);
+  if (!generation) return null;
+
+  return {
+    gameVersion,
+    generation,
+    team,
+    attempts: payload.attempts,
+  };
+}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,6 +1,4 @@
-import type { EvolutionLine, GameVersion, Generation } from "@/lib/types";
-import { getGameData } from "@/data";
-import { getGameVersion, getGenerationForGame } from "@/lib/games";
+import type { EvolutionLine } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -15,13 +13,6 @@ export interface TeamMemberRef {
 export interface SharePayload {
   gameSlug: string;
   members: TeamMemberRef[];
-  attempts: number;
-}
-
-export interface ResolvedShareData {
-  gameVersion: GameVersion;
-  generation: Generation;
-  team: EvolutionLine[];
   attempts: number;
 }
 
@@ -278,44 +269,3 @@ export function decodeShareCode(code: string): SharePayload | null {
   return { gameSlug, members, attempts };
 }
 
-// ---------------------------------------------------------------------------
-// Resolve (full data lookup)
-// ---------------------------------------------------------------------------
-
-/** Decode + resolve full EvolutionLine objects from static game data. Returns null on any failure. */
-export function resolveShareCode(code: string): ResolvedShareData | null {
-  const payload = decodeShareCode(code);
-  if (!payload) return null;
-
-  // 1. getGameData must return data
-  const data = getGameData(payload.gameSlug);
-  if (!data) return null;
-
-  // 2. Each member must be found in game data
-  const team: EvolutionLine[] = [];
-  for (const ref of payload.members) {
-    const line = data.find(
-      (l) =>
-        l.lineId === ref.lineId &&
-        (ref.branchIndex === undefined
-          ? l.branchIndex === undefined
-          : l.branchIndex === ref.branchIndex),
-    );
-    if (!line) return null;
-    team.push(line);
-  }
-
-  // 3. getGameVersion and getGenerationForGame must return values
-  const gameVersion = getGameVersion(payload.gameSlug);
-  if (!gameVersion) return null;
-
-  const generation = getGenerationForGame(gameVersion);
-  if (!generation) return null;
-
-  return {
-    gameVersion,
-    generation,
-    team,
-    attempts: payload.attempts,
-  };
-}


### PR DESCRIPTION
## Summary
Performance and correctness pass. Biggest win: the client no longer downloads the entire Pokémon dataset.

Verified with `eslint` (clean; was **7 errors + 4 warnings**) and a production `next build` (passes).

## Performance
- **Split the 2.9 MB dataset out of client bundles.** `ShareButton` (client) imported `@/lib/share`, which imported the `@/data` barrel (all 38 game JSON files). `/history` and `/play` were loading a **2.9 MB** JS chunk of Pokémon data they don't need. Moved the only data-consuming function (`resolveShareCode`) into a new **server-only** `src/lib/share-resolve.ts`; `share.ts` is now client-safe (encode/decode only).
  - **Total client JS: 3914 KB → 928 KB (−76%).** No page references a client chunk >500 KB anymore.
- Memoized the history migration pass (`useMemo`).
- Made `icon-192` / `icon-512` **static** (dropped `runtime = "edge"`, added `force-static`) — they now prerender instead of rendering per request (build warning gone).

## Correctness / cleanup
- Fixed 3 **"ref accessed during render"** errors in `game-client.tsx` (use `state.team` in render; sync `teamRef` in an effect for the deferred `setTimeout` closures).
- Typed the history migration helpers with `LegacyTeamHistoryEntry` / `Pokemon` + a type guard (removed 4 `any`s).
- Removed dead code (`getOverlappingTeamIndices`, `isLineOnTeam`, `StatChart.primaryType`) and unused imports.
- Replaced the create-next-app boilerplate README with real project docs.

## Notes
- `/play` still delivers each game's data as serialized props (required for client-side card dealing) — unchanged and correct. Only the redundant full-dataset JS chunk was removed.
- Deferred (optional, higher-risk): lazy per-slug data loading (no benefit on a static-exported site) and trimming `/play` props.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>